### PR TITLE
use the correct build command when building spade in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
           git clone https://github.com/hackclub/sprig.git sprig/
           
       - name: 'Build Script'
-        run: cd ~/sprig/firmware/spade && ../../scripts/gardenshed/build.sh
+        run: cd ~/sprig/firmware/spade && python3 gardenshed.py build
       
       - name: 'Upload artifact'
         uses: 'actions/upload-artifact@v3'
         with:
-          name: 'spade.uf2'
-          path: '~/sprig/firmware/spade/spade.uf2'
+          name: 'firmware.uf2'
+          path: '~/sprig/firmware/spade/firmware.uf2'
           if-no-files-found: error


### PR DESCRIPTION

Previously the spade firmware was failing to build in CI because it was using the wrong build command. This PR fixes that.